### PR TITLE
Feature picknchoose

### DIFF
--- a/templates/panorama/snippets/.meta-cnc.yaml
+++ b/templates/panorama/snippets/.meta-cnc.yaml
@@ -254,3 +254,15 @@ snippets:
   - name: email_scheduler
     xpath: /config/devices/entry[@name='localhost.localdomain']/device-group/entry[@name='{{ DEVICE_GROUP }}']/email-scheduler
     file: email_scheduler_simple.xml
+
+quick_groups:
+  security_profiles:
+    - shared_profiles_custom_url_category
+    - profiles_decryption
+    - profiles_virus
+    - profiles_spyware
+    - profiles_vulnerability
+    - profiles_file_blocking
+    - profiles_url_filtering
+    - profiles_wildfire_analysis
+    - profile_group

--- a/templates/panorama/snippets/.meta-cnc.yaml
+++ b/templates/panorama/snippets/.meta-cnc.yaml
@@ -266,3 +266,7 @@ quick_groups:
     - profiles_url_filtering
     - profiles_wildfire_analysis
     - profile_group
+  objects:
+    - shared_tag
+    - shared_address
+    - shared_external_list

--- a/tools/README.md
+++ b/tools/README.md
@@ -57,6 +57,12 @@ python create_and_push.py shared_address shared_tag
 
 Snippets use provided variables from config_variables.yaml.
 
+create_and_push will prompt for username/password/hostname, however, they can all be set using the following
+environment vars:
+- IS_USERNAME
+- IS_PASSWORD
+- IS_ADDRESS
+
 ## Template Admin
 The admin utilities are also python based and assume a working python
 environment. Directions for activating the virtual environment are above.

--- a/tools/README.md
+++ b/tools/README.md
@@ -41,6 +41,22 @@ The output loadable templates, full and snippet configs, are saved in the
 Each run results in a new archive directory allowing for new configs with
 modified variables.
 
+#### create_and_push.py
+Provides a method for cherry-picking aspects of the iron-skillet configuration
+by rendering only the specified snippets.
+
+Automatically pushes the snippets to the provided firewall or Panorama. 
+```bash
+# Display the available snippets
+python create_and_push.py 
+# Push 
+python create_and_push.py shared_tag
+# Push multiple
+python create_and_push.py shared_address shared_tag
+```
+
+Snippets use provided variables from config_variables.yaml.
+
 ## Template Admin
 The admin utilities are also python based and assume a working python
 environment. Directions for activating the virtual environment are above.

--- a/tools/config_variables.yaml
+++ b/tools/config_variables.yaml
@@ -22,13 +22,13 @@ variables:
     value: 192.0.2.3
   - name: TEMPLATE
     description: Template name for Panorama
-    value: sample_template
+    value: iron-skillet
   - name: STACK
     description: Template stack name for Panorama
-    value: sample_stack
+    value: iron-skillet-stack
   - name: DEVICE_GROUP
     description: Device-group name for Panorama
-    value: sample_devicegroup
+    value: iron-skillet
   - name: FW_NAME
     description: Device Name for NGFW
     value: sample

--- a/tools/create_and_push.py
+++ b/tools/create_and_push.py
@@ -51,7 +51,6 @@ class Panos:
         Connect to a PANOS device and retrieve an API key.
         :return: API Key
         """
-        url = self.url
         params = {
             "type": "keygen",
             "user": self.user,
@@ -103,9 +102,13 @@ class Panos:
             print(l)
 
 def sanitize_element(element):
+    """
+    Eliminate some undeeded characters out of the XML snippet if they appear.
+    :param element: element str
+    :return: sanitized element str
+    """
     element = re.sub("\n\s+", "", element)
     element = re.sub("\n", "", element)
-    element = re.sub("b\\'", "", element)
     return element
 
 def set_at_path(panos, xpath, elementvalue):
@@ -146,7 +149,10 @@ def generate_snippet(config_type, snippet_names=None):
     """
     Generate just a snippet for the given snippet_names, or all if asked.
 
+    Uses .meta-cnc.yaml to determine the snippets and xpath values based om the names passed to this function.
+
     :param config_type: currently supported: 'panos' or 'panorama'
+    :param snippet_names: list: List of snippet or snippet group names.
     :return: dict: {"name": snippet name, "element": string element value, "xpath": path to element (from metadata file)}
     """
 

--- a/tools/create_and_push.py
+++ b/tools/create_and_push.py
@@ -41,7 +41,7 @@ class Panos:
         self.user = user
         self.pw = pw
         self.key = ''
-        self.debug = True
+        self.debug = False
         self.connect()
 
 
@@ -162,12 +162,23 @@ def generate_snippet(config_type, snippet_names=None):
     config_path = os.path.abspath(os.path.join('..', 'templates', config_type))
 
     xml_snippets = []
+
+
     if snippet_names:
+        sn_full = []
+        # if the arg is a group, we convert to the underlying snippets
+        for sn in snippet_names:
+            if sn in service_config["quick_groups"]:
+                sn_full = sn_full + service_config["quick_groups"][sn]
+            else:
+                sn_full.append(sn)
+
         for xml_snippet in service_config['snippets']:
-            if xml_snippet['name'] in snippet_names:
+            if xml_snippet['name'] in sn_full:
                 xml_snippets.append(xml_snippet)
     else:
         xml_snippets = service_config['snippets']
+
 
     result = []
     # iterator through the metadata snippets load order
@@ -235,7 +246,7 @@ def check_resp(r, print_result=True):
         return True
     else:
         if print_result:
-            print("{}Failed.".format(Fore.RED))
+            print("{}{} : Failed.".format(Fore.RED, r.text))
             print(Style.RESET_ALL)
         return False
 

--- a/tools/create_and_push.py
+++ b/tools/create_and_push.py
@@ -155,9 +155,18 @@ def generate_snippet(config_type, snippet_names=None):
     :param snippet_names: list: List of snippet or snippet group names.
     :return: dict: {"name": snippet name, "element": string element value, "xpath": path to element (from metadata file)}
     """
+    template_dir_paths = [
+        os.path.join('..', 'templates'),
+        os.path.join('templates')
+    ]
+    for tp in template_dir_paths:
+        if os.path.exists(tp):
+            template_dir_path = tp
 
-    metadata_file = os.path.abspath(os.path.join('..', 'templates', config_type, 'snippets'.format(config_type), '.meta-cnc.yaml'))
+    if not template_dir_path:
+        raise FileNotFoundError("Template directory not found in any known location.")
 
+    metadata_file = os.path.abspath(os.path.join(template_dir_path, config_type, 'snippets'.format(config_type), '.meta-cnc.yaml'))
     try:
         with open(metadata_file, 'r') as snippet_metadata:
             service_config = oyaml.safe_load(snippet_metadata.read())
@@ -167,7 +176,7 @@ def generate_snippet(config_type, snippet_names=None):
         print(ioe)
         sys.exit()
 
-    config_path = os.path.abspath(os.path.join('..', 'templates', config_type))
+    config_path = os.path.abspath(os.path.join(template_dir_path, config_type))
 
     xml_snippets = []
 
@@ -299,7 +308,7 @@ def main():
         r = generate_snippet("panorama")
         for result in r:
             print("{} : {}".format(result["name"], result["xpath"]))
-        exit()
+        sys.exit(0)
     else:
         addr = env_or_prompt("address", prompt_long="address:port (localhost:9443) of PANOS Device to configure: ")
         user = env_or_prompt("username")

--- a/tools/create_and_push.py
+++ b/tools/create_and_push.py
@@ -275,13 +275,11 @@ def check_resp(r, print_result=True):
     status = root.attrib["status"]
     if status == "success":
         if print_result:
-            print("{}Success!".format(Fore.GREEN))
-            print(Style.RESET_ALL)
+            print("{}Success!{}".format(Fore.GREEN, Style.RESET_ALL))
         return True
     else:
         if print_result:
-            print("{}{} : Failed.".format(Fore.RED, r.text))
-            print(Style.RESET_ALL)
+            print("{}{} : Failed.{}".format(Fore.RED, r.text, Style.RESET_ALL))
         return False
 
 
@@ -307,7 +305,7 @@ def main():
             t = "panos"
         result = generate_snippet(t.lower(), sys.argv[1:])
         for r in result:
-            print("Doing {} at {}...".format(r["name"], r["xpath"]))
+            print("Doing {} at {}...".format(r["name"], r["xpath"]), end="")
             r = set_at_path(fw, r["xpath"], r["element"])
             check_resp(r)
 

--- a/tools/create_and_push.py
+++ b/tools/create_and_push.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import oyaml
+import requests
+from xml.etree import ElementTree
+
+class Panos:
+    def __init__(self, addr, user, pw):
+        self.url = "https://{}/api".format(addr)
+        self.user = user
+        self.pw = pw
+        self.key = ''
+        self.connect()
+
+    def connect(self):
+        url = self.url
+        params = {
+            "type": "keygen",
+            "user": self.user,
+            "password": self.pw,
+        }
+        r = requests.get(url, params=params, verify=False)
+        root = ElementTree.fromstring(r.content)
+        elem = root.findall("./result/key")
+        self.key = elem[0].text
+        return self.key
+
+    def send(self, params):
+        url = self.url
+        params["key"] = self.key
+        r = requests.get(url, params=params, verify=False)
+        print(r.text)
+
+def set_at_path(panos, xpath, elementvalue):
+    params = {
+        "type": "config",
+        "action": "set",
+        "xpath": xpath,
+        "element": elementvalue,
+    }
+    panos.send(params)
+
+def generate_snippet(config_type, snippet_names=None):
+    """
+    Generates the full configuration template for a given configuration type (panos or panorama).
+    This will use the load order
+    :param config_type: currently supported: 'panos' or 'panorama'
+    :return: will print full configs to STDOUT and also overwrite the full/iron_skillet_<type>_full.xml
+    """
+    metadata_file = os.path.abspath(os.path.join('..', 'templates', config_type, 'snippets'.format(config_type), '.meta-cnc.yaml'))
+
+    try:
+        with open(metadata_file, 'r') as snippet_metadata:
+            service_config = oyaml.safe_load(snippet_metadata.read())
+
+    except IOError as ioe:
+        print(f'Could not open metadata file {metadata_file}')
+        print(ioe)
+        sys.exit()
+
+    config_path = os.path.abspath(os.path.join('..', 'templates', config_type))
+
+    xml_snippets = []
+    if snippet_names:
+        for xml_snippet in service_config['snippets']:
+            if xml_snippet['name'] in snippet_names:
+                xml_snippets.append(xml_snippet)
+    else:
+        xml_snippets = service_config['snippets']
+
+    result = []
+    # iterator through the metadata snippets load order
+    # parse the snippets into XML objects
+    # attach to the full_config dom
+    for xml_snippet in xml_snippets:
+        # xml_snippet is a set of attributes in the .meta-cnc.yaml file
+        # that includes the xpaths and files listed in the proper load order
+        snippet_name = xml_snippet['file']
+        snippet_path = os.path.join(config_path, 'snippets'.format(config_type), snippet_name)
+
+        # skip snippets that aren't actually there for some reason
+        if not os.path.exists(snippet_path):
+            print(snippet_path)
+            print('this snippet does not actually exist!')
+            sys.exit()
+
+        # read them in
+        with open(snippet_path, 'r') as snippet_obj:
+            snippet_string = snippet_obj.read()
+
+        result.append({"name": xml_snippet["name"], "element": snippet_string, "xpath": xml_snippet["xpath"]})
+
+    return result
+
+
+if len(sys.argv) == 1:
+    print("printing available iron-skillet snippets")
+    r = generate_snippet("panorama")
+    for result in r:
+        print("{} : {}".format(result["name"],result["xpath"]))
+    exit()
+else:
+    fw = Panos("localhost:9443", "admin", "admin")
+    result = generate_snippet("panorama", sys.argv[1:])
+    for r in result:
+        print("Doing {} at {}...".format(r["name"],r["xpath"]))
+        set_at_path(fw, r["xpath"], r["element"])

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -4,4 +4,5 @@ oyaml==0.7
 passlib==1.7.1
 PyYAML==3.13
 XlsxWriter==1.1.2
-requests
+requests==2.22.0
+colorama==0.4.1

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -4,3 +4,4 @@ oyaml==0.7
 passlib==1.7.1
 PyYAML==3.13
 XlsxWriter==1.1.2
+requests


### PR DESCRIPTION
This PR is a result of a recent PSAcademy in which we used _load config partial_ to bring in aspects of the iron-skillet configuration to both firewalls and Panorama.

This PR brings in an additional user script that pulls all the snippet info out of the meta config, renders them using jinja2, and pushes them to a firewall or Panorama.

When run from the command line, you can specify which attributes of iron-skillet to send to the panos device. This eliminates the requirement for users to have to use load config partial or know the exact xpath values to load from and to.

This PR does not include any handling for templates or devicegroups above what already exists.

Submitted against panos_v8.0 because that was the source branch, however, this code should be platform independent and able to be merged with 8.1 (tested) and 9.0 (not tested).

