### PR TITLE
Update README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -31,6 +31,7 @@ Python3.6 is used in the example. Python3.5 or python3.7 may also be used.
 cd iron-skillet/tools
 python3.6 -m venv env
 source env/bin/activate
+pip install wheel
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Description

when following the instructions on a fresh linux install, an obscure message is displayed to the effect of;
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for MarkupSafe

Wheel needs to be installed prior to installing the requirements.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
