### PR TITLE
IronSkillet Timezone Validation Fail Fix

### DIFF
--- a/validations/panos/IronSkillet_assessment_panos/.meta-cnc.yaml
+++ b/validations/panos/IronSkillet_assessment_panos/.meta-cnc.yaml
@@ -104,7 +104,7 @@ snippets:
 
   - name: timezone
     label: timezone set to UTC
-    test: timezone | element_value('timezone') == 'UTC'
+    test: ("UTC" in (timezone | element_value('timezone')))
     fail_message: set to UTC so all devices map to a common universal timezone
     documentation_link: https://iron-skillet.readthedocs.io/en/docs_master/viz_guide_panos.html#device-setup-management-general-settings
 


### PR DESCRIPTION
## Description

Changed the TimeZone snippet within the validation check for the IronSkillet config to allow all options containing "UTC" within them to be valid IronSkillet Configurations. 

## Motivation and Context

This change was required to fix IronSkillet bug report #136: https://github.com/PaloAltoNetworks/iron-skillet/issues/136 

## How Has This Been Tested?

Ran IronSkillet against my VM, changed the Timezone manually and ran the updated validation script. It passed for all variations of UTC showing that the change worked.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
