### PR TITLE
Changed sli reference in loading_the_template.rst file

### DIFF
--- a/docs/loading_the_template.rst
+++ b/docs/loading_the_template.rst
@@ -46,7 +46,7 @@ with skillets including IronSkillet.
 installing and using SLI
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please refer to the README document found within the following `SLI <https://gitlab.com/panw-gse/as/sli>`_
+Please refer to the README document found within the following `SLI <https://pypi.org/project/sli/>`_
 repository. This will walk you through the installation and basic usage of SLI in the context of
 skillets.
 


### PR DESCRIPTION
## Description

Changed one SLI reference that was pointing at GitLab in the loading_the_template.rst file under the docs_master branch. It now points at SLI PyPi. 

## Motivation and Context

Needed for gitlab/github internal privacy changes being made.

## How Has This Been Tested?

Ran the `make html` command and tested the webpage locally, worked fine.
