### PR TITLE
Fix Exception-VP profile Bug

### DIFF
--- a/templates/panorama/snippets_dgstack_notshared/.meta-cnc.yaml
+++ b/templates/panorama/snippets_dgstack_notshared/.meta-cnc.yaml
@@ -1843,11 +1843,11 @@ snippets:
     cmd: set
 
 -   name: panorama_profiles_vulnerability_10_1.ironskillet_vulnerability_exception
-    xpath: /config/devices/entry[@name='localhost.localdomain']/device-group/entry[@name='{{DEVICE_GROUP}}']/profiles/vulnerability
+    xpath: /config/devices/entry[@name='localhost.localdomain']/device-group/entry[@name='{{DEVICE_GROUP}}']/profiles
     element: |-
-        <entry name="Exception-VP">
-          <rules/>
-        </entry>
+        <vulnerability>
+            <entry name="Exception-VP"/>
+        </vulnerability>
     cmd: set
 
 -   name: panorama_profiles_file_blocking_10_1.ironskillet_file_blocking_outbound


### PR DESCRIPTION
Fixed a Bug for the Panorama NotShared DG IronSkillet 10.1 where the XML for the Exception VP profile had an unnecessary piece of XML within it, thus throwing an error

Tested this skillet against a local Panorama instance along with all other skillets in the same directory. They all worked as expected.
