### PR TITLE
bug fixes for iron_skillet_full configuration for 10.1

### DIFF
--- a/templates/panos/full/iron_skillet_panos_full.xml
+++ b/templates/panos/full/iron_skillet_panos_full.xml
@@ -92,6 +92,19 @@
         </entry>
       </match-list>
     </config>
+    <syslog>
+      <entry name="Sample_Syslog_Profile">
+        <server>
+          <entry name="Sample_Syslog">
+            <transport>UDP</transport>
+            <port>514</port>
+            <format>BSD</format>
+            <server>192.0.2.2</server>
+            <facility>LOG_USER</facility>
+          </entry>
+        </server>
+      </entry>
+    </syslog>
     <system>
       <match-list>
         <entry name="System_Log_Forwarding">
@@ -101,23 +114,6 @@
             <member>Sample_Syslog_Profile</member>
           </send-syslog>
         </entry>
-      </match-list>
-    </system>
-    <syslog>
-      <entry name="Sample_Syslog_Profile">
-        <server>
-          <entry name="Sample_Syslog">
-            <transport>UDP</transport>
-            <port>514</port>
-            <format>BSD</format>
-            <server>{{SYSLOG_SERVER}}</server>
-            <facility>LOG_USER</facility>
-          </entry>
-        </server>
-      </entry>
-    </syslog>
-      <system>
-        <match-list>
         <entry name="Email_Critical_System_Logs">
              <send-email>
                <member>Sample_Email_Profile</member>
@@ -527,38 +523,6 @@
             </global-protect-app-crypto-profiles>
           </crypto-profiles>
         </ike>
-        <qos>
-          <profile>
-            <entry name="default">
-              <class>
-                <entry name="class1">
-                  <priority>real-time</priority>
-                </entry>
-                <entry name="class2">
-                  <priority>high</priority>
-                </entry>
-                <entry name="class3">
-                  <priority>high</priority>
-                </entry>
-                <entry name="class4">
-                  <priority>medium</priority>
-                </entry>
-                <entry name="class5">
-                  <priority>medium</priority>
-                </entry>
-                <entry name="class6">
-                  <priority>low</priority>
-                </entry>
-                <entry name="class7">
-                  <priority>low</priority>
-                </entry>
-                <entry name="class8">
-                  <priority>low</priority>
-                </entry>
-              </class>
-            </entry>
-          </profile>
-        </qos>
         <virtual-router>
           <entry name="default">
             <protocol>
@@ -729,29 +693,19 @@
           <report-grayware-file>yes</report-grayware-file>
         </wildfire>
         <management>
-          <auto-acquire-commit-lock>yes</auto-acquire-commit-lock>
-        </management>
-        <management>
-          <idle-timeout>10</idle-timeout>
-        </management>
-        <management>
+          <enable-log-high-dp-load>yes</enable-log-high-dp-load>
+          <max-rows-in-csv-export>1048576</max-rows-in-csv-export>
+          <api>
+            <key>
+              <lifetime>525600</lifetime>
+            </key>
+          </api>
           <admin-lockout>
             <failed-attempts>5</failed-attempts>
             <lockout-time>30</lockout-time>
           </admin-lockout>
-        </management>
-        <management>
-          <api>
-            <key>
-              <lifetime>{{API_KEY_LIFETIME}}</lifetime>
-            </key>
-          </api>
-        </management>
-        <management>
-          <max-rows-in-csv-export>1048576</max-rows-in-csv-export>
-        </management>
-        <management>
-          <enable-log-high-dp-load>yes</enable-log-high-dp-load>
+          <idle-timeout>10</idle-timeout>
+          <auto-acquire-commit-lock>yes</auto-acquire-commit-lock>
         </management>
         <ctd>
           <tcp-bypass-exceed-queue>no</tcp-bypass-exceed-queue>

--- a/templates/panos/full/iron_skillet_panos_full.xml
+++ b/templates/panos/full/iron_skillet_panos_full.xml
@@ -99,7 +99,7 @@
             <transport>UDP</transport>
             <port>514</port>
             <format>BSD</format>
-            <server>192.0.2.2</server>
+            <server>{{ SYSLOG_SERVER }}</server>
             <facility>LOG_USER</facility>
           </entry>
         </server>
@@ -697,7 +697,7 @@
           <max-rows-in-csv-export>1048576</max-rows-in-csv-export>
           <api>
             <key>
-              <lifetime>525600</lifetime>
+              <lifetime>{{ API_KEY_LIFETIME }}</lifetime>
             </key>
           </api>
           <admin-lockout>


### PR DESCRIPTION
## Description

Submitted bug fixes when loading the IronSkillet Full XML file for Panos resulting in only partial configurations being loaded, including duplicate management nodes, duplicate external-list nodes, flawed QoS profile and duplicate log-settings node.

## Motivation and Context

Bug fix for Errors

## How Has This Been Tested?

Tested Locally.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
