### PR TITLE
Update README.md for incorrect link for 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ Prior to utilizing these configuration templates, it is important to
 familiarize yourself with the best practice recommendations for
 Internet Gateway, Datacenter, Wildfire, L4-L7 evasions and other use cases.
 
-[Best Practice Recommendations](https://www.paloaltonetworks.com/documentation/best-practices)
+[Best Practice Recommendations](https://docs.paloaltonetworks.com/best-practices)
 
 While useful as suggestions and recommendations, the user is still required
 to manually use the GUI or CLI to configure each recommendation.
 
 
 ## Contributing
-Please read [CONTRIBUTING.md](https://github.com/PaloAltoNetworks/iron-skillet/CONTRIBUTING.md) for details on how you can help contribute to this project.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how you can help contribute to this project.
 
 ## Support
 This is a Palo Alto Networks contributed project.
@@ -139,4 +139,4 @@ See also the list of [contributors](https://github.com/PaloAltoNetworks/iron-ski
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details


### PR DESCRIPTION
## Description
Submitted changes to update README.md link, including "Best Practice Recommendations", "CONTRIBUTING.md" and "LICENSE".

1. Best practices page already moved from
    https://www.paloaltonetworks.com/documentation/best-practices
    to
    https://docs.paloaltonetworks.com/best-practices

2. Change CONTRIBUTING.md from fixed link to relative link

3. LICENSE.md move to LICENSE
